### PR TITLE
Add support for routing builders

### DIFF
--- a/ktor/build.gradle
+++ b/ktor/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compileOnly "io.ktor:ktor-server-tomcat:$ktor_version"
     compileOnly "io.ktor:ktor-server-jetty:$ktor_version"
 
+    testCompile "io.ktor:ktor-auth:$ktor_version"
     testCompile "io.ktor:ktor-server-netty:$ktor_version"
     testCompile "io.micronaut:micronaut-http-client:$micronautVersion"
     testCompile "io.micronaut.test:micronaut-test-junit5:1.0.1"

--- a/ktor/src/main/kotlin/io/micronaut/ktor/KtorRoutingBuilder.kt
+++ b/ktor/src/main/kotlin/io/micronaut/ktor/KtorRoutingBuilder.kt
@@ -1,0 +1,11 @@
+package io.micronaut.ktor
+
+import io.ktor.routing.Routing
+
+/**
+ * Allows declaring classes that can configure Ktor routes
+ *
+ * @author edrd-f
+ * @since 1.0
+ */
+abstract class KtorRoutingBuilder(val builder: Routing.() -> Unit)

--- a/ktor/src/main/kotlin/io/micronaut/ktor/factory/MicronautKtorApplication.kt
+++ b/ktor/src/main/kotlin/io/micronaut/ktor/factory/MicronautKtorApplication.kt
@@ -15,6 +15,7 @@
  */
 package io.micronaut.ktor.factory
 
+import io.ktor.routing.routing
 import io.ktor.server.engine.*
 import io.ktor.util.KtorExperimentalAPI
 import io.micronaut.context.annotation.Bean
@@ -25,6 +26,7 @@ import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.http.server.HttpServerConfiguration
 import io.micronaut.ktor.KtorApplication
 import io.micronaut.ktor.KtorApplicationBuilder
+import io.micronaut.ktor.KtorRoutingBuilder
 import io.micronaut.ktor.env.MicronautKotrEnvironmentConfig
 import javax.inject.Singleton
 
@@ -39,11 +41,20 @@ class KtorMicronautApplicationFactory {
     @Bean
     fun applicationEngineEnvironmentBuilder(
             ktorApplication: KtorApplication<*>,
-            ktorApplicationBuilders: List<KtorApplicationBuilder>) : ApplicationEngineEnvironmentBuilder {
+            ktorApplicationBuilders: List<KtorApplicationBuilder>,
+            ktorRoutingBuilders: List<KtorRoutingBuilder>) : ApplicationEngineEnvironmentBuilder {
         ktorApplication.init()
+
         ktorApplicationBuilders.forEach {
             ktorApplication.environment.modules.add(it.builder)
         }
+
+        ktorRoutingBuilders.forEach {
+            ktorApplication.environment.modules.add {
+                routing { it.builder(this) }
+            }
+        }
+
         return ktorApplication.environment
     }
 

--- a/ktor/src/test/kotlin/app/AppTest.kt
+++ b/ktor/src/test/kotlin/app/AppTest.kt
@@ -17,9 +17,11 @@ package app
 
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.annotation.MicronautTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
 import javax.inject.Inject
 
 @MicronautTest
@@ -27,13 +29,22 @@ class AppTest {
 
     @Inject
     @field:Client("/")
-    lateinit var client : RxHttpClient
+    lateinit var client: RxHttpClient
 
     @Test
     fun testApp() {
         assertEquals(
-                "Hello World",
-                client.toBlocking().retrieve("/demo")
+            "Hello World",
+            client.toBlocking().retrieve("/demo")
         )
+    }
+
+    @Test
+    fun testFeatureDependentRoute() {
+        val exception = assertThrows<HttpClientResponseException>() {
+            client.toBlocking().retrieve("/authenticated")
+        }
+
+        assertEquals("Unauthorized", exception.message)
     }
 }

--- a/ktor/src/test/kotlin/app/AuthenticationBuilder.kt
+++ b/ktor/src/test/kotlin/app/AuthenticationBuilder.kt
@@ -1,0 +1,16 @@
+package app
+
+import io.ktor.application.install
+import io.ktor.auth.Authentication
+import io.ktor.auth.basic
+import io.micronaut.ktor.KtorApplicationBuilder
+import javax.inject.Singleton
+
+@Singleton
+class AuthenticationBuilder : KtorApplicationBuilder({
+    install(Authentication) {
+        basic {
+            validate { null }
+        }
+    }
+})

--- a/ktor/src/test/kotlin/app/GreetingRoutes.kt
+++ b/ktor/src/test/kotlin/app/GreetingRoutes.kt
@@ -1,21 +1,26 @@
 package app
 
 import io.ktor.application.call
+import io.ktor.auth.authenticate
+import io.ktor.http.ContentType
 import io.ktor.response.respondText
 import io.ktor.routing.get
-import io.ktor.routing.routing
-import io.ktor.http.ContentType
-import io.micronaut.ktor.KtorApplicationBuilder
+import io.micronaut.ktor.KtorRoutingBuilder
 import javax.inject.Singleton
 
 @Singleton
-class GreetingRoutes(private val greetingService: GreetingService) : KtorApplicationBuilder({
-    routing {
-        get("/") {
-            call.respondText(greetingService.greet(), ContentType.Text.Plain)
+class GreetingRoutes(private val greetingService: GreetingService) : KtorRoutingBuilder({
+    authenticate {
+        get("/authenticated") {
+            call.respondText("Hello from authenticated route")
         }
-        get("/demo") {
-            call.respondText(greetingService.greet())
-        }
+    }
+
+    get("/") {
+        call.respondText(greetingService.greet(), ContentType.Text.Plain)
+    }
+
+    get("/demo") {
+        call.respondText(greetingService.greet())
     }
 })


### PR DESCRIPTION
Creates a `KtorRoutingBuilder`, which uses the `Routing` DSL and modifies the application factory to load builders in the correct order.

Usage example:

```kotlin
@Singleton
class GreetingRoutes(private val greetingService: GreetingService) : KtorRoutingBuilder({
    get("/hello") {
        call.respondText(greetingService.greet())
    }
})
```

Fixes issue https://github.com/micronaut-projects/micronaut-kotlin/issues/17