### PR TITLE
Resolve configuration 

### DIFF
--- a/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoader.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoader.kt
@@ -24,6 +24,7 @@ import io.micronaut.core.io.ResourceLoader
 import io.micronaut.core.reflect.ClassUtils
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.*
 import kotlin.collections.LinkedHashMap
@@ -48,7 +49,7 @@ class HoconPropertySourceLoader : PropertySourceLoader {
         val config = ConfigFactory.parseReader(InputStreamReader(input, StandardCharsets.UTF_8))
         if (name != null) {
             val entrySet = config.entrySet()
-            val map : MutableMap<String, Any> = LinkedHashMap()
+            val map: MutableMap<String, Any> = LinkedHashMap()
             for (entry in entrySet) {
                 val key = entry.key
                 val value = entry.value
@@ -64,21 +65,24 @@ class HoconPropertySourceLoader : PropertySourceLoader {
                 val qualifiedName = "$resourceName-$environmentName"
                 val resource = resourceLoader?.getResource("$qualifiedName.conf")
                 if (resource != null && resource.isPresent) {
-                    val url = resource.get()
-                    val config = ConfigFactory.parseURL(url)
+                    val config = resource.get().parseConfig()
                     return Optional.of(ConfigPropertySource(qualifiedName, config))
                 }
             } else {
                 val resource = resourceLoader?.getResource("$resourceName.conf")
                 if (resource != null && resource.isPresent) {
-                    val url = resource.get()
-                    val config = ConfigFactory.parseURL(url)
+                    val config = resource.get().parseConfig()
                     return Optional.of(ConfigPropertySource(resourceName, config))
                 }
             }
         }
         return Optional.empty()
     }
+
+    private fun URL.parseConfig(): Config =
+            ConfigFactory
+                    .parseURL(this)
+                    .resolve()
 }
 
 class ConfigPropertySource(private val sourceName: String, private val config: Config) : PropertySource {

--- a/kotlin-runtime/src/test/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoaderTest.kt
+++ b/kotlin-runtime/src/test/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoaderTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test
 
 class HoconPropertySourceLoaderTest {
 
-
     @Test
     fun testPropertySourceLoader() {
         val env = DefaultEnvironment()
@@ -31,4 +30,16 @@ class HoconPropertySourceLoaderTest {
                 value.get().toInt() == 8081
         )
     }
+
+    @Test
+    fun testPropertySourceLoaderEnvironmentVariable() {
+        val env = DefaultEnvironment()
+        env.start()
+
+        val value = env.getProperty("custom.user", String::class.java)
+        assert(
+                value.get() == System.getProperty("user.name")
+        )
+    }
+
 }

--- a/kotlin-runtime/src/test/resources/application.conf
+++ b/kotlin-runtime/src/test/resources/application.conf
@@ -3,3 +3,7 @@ micronaut {
     port = 8081
   }
 }
+
+custom {
+  user = ${USER}
+}


### PR DESCRIPTION
Resolve configuration to allow for value substitution as is supported by HOCON.

Calls the `resolve()` method on the Typesafe `Config` object which will resolve all subsitutions
 (inner references, environment variables, properties).