### PR TITLE
Configuration file should not shadow environment variables

### DIFF
--- a/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoader.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoader.kt
@@ -18,6 +18,7 @@ package io.micronaut.context.env.hocon
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValue
+import io.micronaut.context.env.EnvironmentPropertySource
 import io.micronaut.context.env.PropertySource
 import io.micronaut.context.env.PropertySourceLoader
 import io.micronaut.core.io.ResourceLoader
@@ -82,6 +83,11 @@ class HoconPropertySourceLoader : PropertySourceLoader {
 }
 
 class ConfigPropertySource(private val sourceName: String, private val config: Config) : PropertySource {
+
+    override fun getOrder(): Int {
+        return EnvironmentPropertySource.POSITION - 100
+    }
+
     override fun getName(): String {
         return sourceName
     }

--- a/kotlin-runtime/src/test/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoaderTest.kt
+++ b/kotlin-runtime/src/test/kotlin/io/micronaut/context/env/hocon/HoconPropertySourceLoaderTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test
 
 class HoconPropertySourceLoaderTest {
 
-
     @Test
     fun testPropertySourceLoader() {
         val env = DefaultEnvironment()
@@ -31,4 +30,20 @@ class HoconPropertySourceLoaderTest {
                 value.get().toInt() == 8081
         )
     }
+
+    @Test
+    fun testPropertySourceLoaderOrder() {
+        System.setProperty("test-property", "good value")
+
+        val env = DefaultEnvironment()
+        env.start()
+
+        val value = env.getProperty("test-property", String::class.java)
+        assert(
+                value.get() == "good value"
+        )
+
+        System.clearProperty("test-property")
+    }
+
 }

--- a/kotlin-runtime/src/test/resources/application.conf
+++ b/kotlin-runtime/src/test/resources/application.conf
@@ -3,3 +3,5 @@ micronaut {
     port = 8081
   }
 }
+
+test-property = "bad-value"


### PR DESCRIPTION
We are having an issue overwriting a property which has been declared in `application.conf` using either an Environment variable or a System property. This was traced back to the ordering of `PropertySource`s. It seems `ConfigPropertySource` takes precedence (order=0).

To resolve this the Order has been changed in line with Micronauts YAML Property Source.