### PR TITLE
Update CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Micronaut Kotlin
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.micronaut.kotlin/micronaut-kotlin-runtime.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.micronaut.kotlin%22%20AND%20a:%22micronaut-kotlin-runtime%22)
-[![Build Status](https://travis-ci.org/micronaut-projects/micronaut-kotlin.svg?branch=master)](https://travis-ci.org/micronaut-projects/micronaut-kotlin)
+![Java CI](https://github.com/micronaut-projects/micronaut-kotlin/workflows/Java%20CI/badge.svg?branch=master)
 
 This project includes integrations between [Micronaut](http://micronaut.io) and [Kotlin](https://kotlinlang.org/) and [Ktor](https://ktor.io/).
 


### PR DESCRIPTION
Looks like the Travis build is not working anymore and GitHub actions are being used instead. This PR simply updates the status badge on the README to reflect this change. 