### PR TITLE
Fix runtime issues in native-image+kotlin

### DIFF
--- a/kotlin-runtime/build.gradle
+++ b/kotlin-runtime/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
     kapt "io.micronaut:micronaut-inject-java:$micronautVersion"
 
+    compileOnly "org.graalvm.nativeimage:svm"
+
     api "io.micronaut:micronaut-inject:$micronautVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.2", {
         exclude group:"org.jetbrains.kotlin", module:'kotlin-reflect'

--- a/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/nativeimage/HoconFeature.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/nativeimage/HoconFeature.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.env.hocon.nativeimage
+
+import com.oracle.svm.core.annotate.AutomaticFeature
+import io.micronaut.context.env.hocon.HoconPropertySourceLoaderImpl
+import io.micronaut.core.annotation.Internal
+import org.graalvm.nativeimage.hosted.Feature
+import org.graalvm.nativeimage.hosted.Feature.BeforeAnalysisAccess
+import org.graalvm.nativeimage.hosted.RuntimeReflection
+
+/**
+ * Kotlin feature to configure platform initialization and reflection details for native image.
+ *
+ * @author Marcelo Liberato
+ * @since 2.0.1
+ */
+@AutomaticFeature
+@Internal
+class HoconFeature: Feature {
+
+    override fun beforeAnalysis(access: BeforeAnalysisAccess) {
+        access.findClassByName("com.typesafe.config.Config")?.let {
+            registerClassForRuntimeReflection(it)
+            registerClassForRuntimeReflection(HoconPropertySourceLoaderImpl::class.java)
+        }
+    }
+
+    private fun registerClassForRuntimeReflection(clazz: Class<*>) {
+        RuntimeReflection.register(clazz)
+        RuntimeReflection.registerForReflectiveInstantiation(clazz)
+    }
+
+}

--- a/kotlin-runtime/src/main/kotlin/io/micronaut/kotlin/nativeimage/KotlinFeature.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/kotlin/nativeimage/KotlinFeature.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.nativeimage
+
+import com.oracle.svm.core.annotate.AutomaticFeature
+import io.micronaut.core.annotation.Internal
+import io.micronaut.core.graal.AutomaticFeatureUtils
+import org.graalvm.nativeimage.hosted.Feature
+import org.graalvm.nativeimage.hosted.Feature.BeforeAnalysisAccess
+
+/**
+ * Kotlin feature to configure platform initialization and reflection details for native image.
+ *
+ * @author Marcelo Liberato
+ * @since 2.0.1
+ */
+@AutomaticFeature
+@Internal
+class KotlinFeature: Feature {
+
+    override fun beforeAnalysis(access: BeforeAnalysisAccess) {
+        arrayOf("kotlin.internal.jdk8.JDK8PlatformImplementations",
+                "kotlin.internal.JRE8PlatformImplementations",
+                "kotlin.internal.jdk7.JDK7PlatformImplementations",
+                "kotlin.internal.JRE7PlatformImplementations")
+                .forEach { AutomaticFeatureUtils.registerClassForRuntimeReflection(access, it) }
+    }
+
+}


### PR DESCRIPTION
Kotlin's PlatformImplementations are instantiated using reflection (depending on the current JVM) and must be configured properly to run on native-image.

Link to relevant code in Kotlin source (highlighted):
https://github.com/JetBrains/kotlin/blob/65244b4bea81f737466618927d4f3afe339cad0d/libraries/stdlib/jvm/src/kotlin/internal/PlatformImplementations.kt#L41-L53

As suggested it was implemented as an `@AutomaticFeature` that runs only at native-image generation time.

By including `compileOnly "org.graalvm.nativeimage:svm"`, existing `HoconPropertySourceLoader` was trying to automatically be configured, exposing another error.

I've address that as well by decoupling `HoconPropertySourceLoader` from `com.typesafe.config.Config`. Everthing seems to be working. It was tested on GraalVM 20.1.0 and 20.2.0 (java11 and java8 versions).

If you think `nativeimage.KotlinFeature` provided here is better suited at `micronaut-runtime`, let me know and I'll be happy to send it again over there.

Fixes: https://github.com/micronaut-projects/micronaut-core/issues/3961