### PR TITLE
Add BeanLocator.getBean(name) extension

### DIFF
--- a/kotlin-extension-functions/src/main/kotlin/io/micronaut/context/BeanLocatorExtensions.kt
+++ b/kotlin-extension-functions/src/main/kotlin/io/micronaut/context/BeanLocatorExtensions.kt
@@ -15,6 +15,7 @@
  */
 package io.micronaut.context
 
+import io.micronaut.inject.qualifierByName
 import io.micronaut.inject.qualifierByStereotype
 import java.util.stream.Stream
 import kotlin.streams.asSequence
@@ -28,6 +29,17 @@ import kotlin.streams.asSequence
  * @since 1.0.0
  */
 inline fun <reified T> BeanLocator.getBean(): T = getBean(T::class.java)
+
+/**
+ * Extension for [BeanLocator.getBean] providing a `getBean<Foo>(name)` variant.
+ *
+ * @param T The bean type
+ * @param name The bean name
+ * @return The bean instance
+ * @author Luiz Picanço
+ * @since 2.1.2
+ */
+inline fun <reified T> BeanLocator.getBean(name: String): T = getBean(T::class.java, qualifierByName(name))
 
 /**
  * Extension for [BeanLocator.getBean] providing a `getStereotypedBean<Foo, Bar>()` variant.

--- a/kotlin-extension-functions/src/main/kotlin/io/micronaut/inject/QualifiersExtensions.kt
+++ b/kotlin-extension-functions/src/main/kotlin/io/micronaut/inject/QualifiersExtensions.kt
@@ -44,3 +44,15 @@ inline fun <reified T, reified Q : Annotation> qualifierByAnnotation(metadata: A
  * @since 1.0.0
  */
 inline fun <reified T, reified Q : Annotation> qualifierByStereotype(): Qualifier<T> = Qualifiers.byStereotype(Q::class.java)
+
+/**
+ *  Top level function acting as a Kotlin shortcut allowing to write `qualifierByName<Foo>(name)`
+ *  instead of `Qualifiers.byStereotype(Bar::class.java)`.
+ *
+ * @param T The component type
+ * @param name The name
+ * @return The [Qualifier]
+ * @author Luiz Picanço
+ * @since 2.1.2
+ */
+inline fun <reified T> qualifierByName(name: String): Qualifier<T> = Qualifiers.byName(name)

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/context/BeanContextExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/context/BeanContextExtensionsTest.kt
@@ -97,6 +97,13 @@ class BeanContextTest {
     }
 
     @Test
+    fun getBeanByName() {
+        assertThrows<NoSuchBeanException> { context.getBean<TestFactory.Foo>("invalid") }
+        assertThrows<NoSuchBeanException> { context.getBean<TestFactory.Qux>("foo") }
+        assertNotNull(context.getBean<TestFactory.Foo>("foo"))
+    }
+
+    @Test
     fun getStereotypedBean() {
         assertThrows<NoSuchBeanException> { context.getStereotypedBean<TestFactory.Qux, Context>() }
         assertNotNull(context.getStereotypedBean<TestFactory.Foo, Prototype>())

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/inject/QualifiersExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/inject/QualifiersExtensionsTest.kt
@@ -46,4 +46,14 @@ class QualifiersExtensionsTest {
         assertEquals(result::class, Qualifiers.byAnnotation<Context>(metadata, Context::class.java)::class)
         assertEquals((result as Named).name, (Qualifiers.byAnnotation<Context>(metadata, Context::class.java) as Named).name)
     }
+
+    @Test
+    fun qualifierByName() {
+        // given
+        val name = "foo"
+        // when
+        val result = qualifierByName<Any>(name)
+        // then
+        assertEquals(name, (result as Named).name)
+    }
 }


### PR DESCRIPTION
Adds two new functions for get beans by name:

-  `BeanLocator.getBean(name)`
- `qualifierByName`

Resolves #118 