### PR TITLE
Fix for Kotlin/coroutines in graalvm after changes in AutomaticFeatureUtils

### DIFF
--- a/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/nativeimage/HoconFeature.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/context/env/hocon/nativeimage/HoconFeature.kt
@@ -18,9 +18,9 @@ package io.micronaut.context.env.hocon.nativeimage
 import com.oracle.svm.core.annotate.AutomaticFeature
 import io.micronaut.context.env.hocon.HoconPropertySourceLoaderImpl
 import io.micronaut.core.annotation.Internal
+import io.micronaut.core.graal.AutomaticFeatureUtils
 import org.graalvm.nativeimage.hosted.Feature
 import org.graalvm.nativeimage.hosted.Feature.BeforeAnalysisAccess
-import org.graalvm.nativeimage.hosted.RuntimeReflection
 
 /**
  * Kotlin feature to configure platform initialization and reflection details for native image.
@@ -34,13 +34,7 @@ class HoconFeature: Feature {
 
     override fun beforeAnalysis(access: BeforeAnalysisAccess) {
         access.findClassByName("com.typesafe.config.Config")?.let {
-            registerClassForRuntimeReflection(HoconPropertySourceLoaderImpl::class.java)
+            AutomaticFeatureUtils.registerClassForRuntimeReflectionAndReflectiveInstantiation(HoconPropertySourceLoaderImpl::class.java)
         }
     }
-
-    private fun registerClassForRuntimeReflection(clazz: Class<*>) {
-        RuntimeReflection.register(clazz)
-        RuntimeReflection.registerForReflectiveInstantiation(clazz)
-    }
-
 }

--- a/kotlin-runtime/src/main/kotlin/io/micronaut/kotlin/nativeimage/KotlinFeature.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/kotlin/nativeimage/KotlinFeature.kt
@@ -36,7 +36,7 @@ class KotlinFeature: Feature {
                 "kotlin.internal.JRE8PlatformImplementations",
                 "kotlin.internal.jdk7.JDK7PlatformImplementations",
                 "kotlin.internal.JRE7PlatformImplementations")
-                .forEach { AutomaticFeatureUtils.registerClassForRuntimeReflection(access, it) }
+                .forEach { AutomaticFeatureUtils.registerClassForRuntimeReflectiveInstantiation(access, it) }
     }
 
 }

--- a/kotlin-runtime/src/main/kotlin/io/micronaut/kotlin/nativeimage/KotlinFeature.kt
+++ b/kotlin-runtime/src/main/kotlin/io/micronaut/kotlin/nativeimage/KotlinFeature.kt
@@ -37,6 +37,23 @@ class KotlinFeature: Feature {
                 "kotlin.internal.jdk7.JDK7PlatformImplementations",
                 "kotlin.internal.JRE7PlatformImplementations")
                 .forEach { AutomaticFeatureUtils.registerClassForRuntimeReflectiveInstantiation(access, it) }
+
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+                access,
+                "kotlin.reflect.jvm.internal.ReflectionFactoryImpl"
+        )
+
+        AutomaticFeatureUtils.registerAllForRuntimeReflection(
+                access,
+                "kotlin.KotlinVersion"
+        )
+
+        AutomaticFeatureUtils.registerClassForRuntimeReflection(access, "kotlin.KotlinVersion\$Companion")
+
+        AutomaticFeatureUtils.addResourcePatterns(
+                "META-INF/.*.kotlin_module\$",
+                ".*.kotlin_builtins"
+        )
     }
 
 }


### PR DESCRIPTION
Some changes in `AutomaticFeatureUtils` have broken setup of kotlin internal classes needed by graalvm.

This PR fixes this regression https://github.com/micronaut-projects/micronaut-core/issues/3961 in micronaut 2.0.2 to 2.1.0