### PR TITLE
adds nativeImage args for Ktor interop with Graal [#163]

### DIFF
--- a/ktor/src/main/resources/META-INF/native-image/io.micronaut.kotlin/micronaut-ktor/native-image.properties
+++ b/ktor/src/main/resources/META-INF/native-image/io.micronaut.kotlin/micronaut-ktor/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=io.ktor,kotlinx,kotlin


### PR DESCRIPTION
See #163 

I think this [PR](https://github.com/micronaut-projects/micronaut-kotlin/pull/222) took care of the `reflect-config.json` issue but I will test this to be certain. If I still see the issue I will add one specifically for Ktor