### PR TITLE
Fixes gh build issue related to dokka [#78]

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,7 +42,8 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: ./gradlew publishToSonatype docs --no-daemon
+        # Edited below to add MaxMetaspace for dokka workaround
+        run: ./gradlew publishToSonatype docs --no-daemon -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=350m"
       - name: Determine docs target repository
         uses: haya14busa/action-cond@v1
         id: docs_target

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,17 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
 
         classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.3"
     }
+}
+
+plugins {
+    id("org.jetbrains.dokka") version "${dokka_version}"
+}
+
+repositories {
+    jcenter() // or maven(url="https://dl.bintray.com/kotlin/dokka")
 }
 
 subprojects { Project subproject ->
@@ -21,7 +28,6 @@ subprojects { Project subproject ->
 
 apply plugin: "io.micronaut.build.internal.docs"
 apply plugin: "io.micronaut.build.internal.dependency-updates"
-apply plugin: 'org.jetbrains.dokka'
 
 tasks.named("dokkaHtmlMultiModule") {
     outputDirectory.set(new File("${rootProject.buildDir}/docs/api"))


### PR DESCRIPTION
I tried to test this as extensively as possible (to avoid further builds breaking), against Java 8, 11, and 15. 350mb metaspace was the lowest place I could reliably get all three to pas.

Ran 3 times for each java version, `./gradlew clean docs --no-daemon -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=350m`, completion times for each were around 1 minute each.