### PR TITLE
Hotfix for building docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,3 +42,14 @@ task renameDokkaRootFile(type: Copy) {
 renameDokkaRootFile.dependsOn(dokkaHtmlMultiModule)
 
 docs.dependsOn(renameDokkaRootFile)
+
+def prepareGuideHotfix = tasks.register("prepareGuideHotfix") {
+    doLast {
+        file("${buildDir}/doc-resources").mkdirs()
+    }
+}
+
+tasks.named('publishGuide') {
+    dependsOn(prepareGuideHotfix)
+    dependsOn(tasks.javadoc)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+
 projectVersion=2.3.1-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
 micronautVersion=2.4.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,9 @@ include "kotlin-runtime"
 include "ktor"
 include "kotlin-extension-functions"
 include "examples:greeting"
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}


### PR DESCRIPTION
The `publishGuide` task isn't configured properly, in the sense that it doesn't declare
all its inputs. Recent versions of Gradle are able to capture those problems and report
them as errors: they basically indicate that the task would have accidentally worked in
the past.

This commit just patches the build to introduce proper ordering and create the expected
directories before the task is executed.