### PR TITLE
Add native image config to fix #7107

### DIFF
--- a/kotlin-runtime/src/main/resources/META-INF/native-image/io.micronaut.kotlin/kotlin-runtime/native-image.properties
+++ b/kotlin-runtime/src/main/resources/META-INF/native-image/io.micronaut.kotlin/kotlin-runtime/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=com.fasterxml.jackson.module.kotlin


### PR DESCRIPTION
The Jackson module for Kotlin needs to be initialized at runtime it seems.

Fixes #7107