### PR TITLE
Update to 3.5.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ projectVersion=3.3.0-SNAPSHOT
 projectGroup=io.micronaut.kotlin
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.4.4
-micronautTestVersion=3.1.1
+micronautVersion=3.5.4
+micronautTestVersion=3.4.0
 groovyVersion=3.0.10
 spockVersion=2.1-groovy-3.0
 

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/inject/QualifiersExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/inject/QualifiersExtensionsTest.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.kotlin.inject
 
 import io.micronaut.context.annotation.Context
@@ -41,10 +26,9 @@ class QualifiersExtensionsTest {
         // given
         val metadata = AnnotationMetadata.EMPTY_METADATA
         // when
-        val result = io.micronaut.kotlin.inject.qualifierByAnnotation<Any, Context>(metadata)
+        val result = qualifierByAnnotation<Any, Context>(metadata)
         // then
         assertEquals(result::class, Qualifiers.byAnnotation<Context>(metadata, Context::class.java)::class)
-        assertEquals((result as Named).name, (Qualifiers.byAnnotation<Context>(metadata, Context::class.java) as Named).name)
     }
 
     @Test
@@ -52,7 +36,7 @@ class QualifiersExtensionsTest {
         // given
         val name = "foo"
         // when
-        val result = io.micronaut.kotlin.inject.qualifierByName<Any>(name)
+        val result = qualifierByName<Any>(name)
         // then
         assertEquals(name, (result as Named).name)
     }


### PR DESCRIPTION
AnnotationMetadataQualifier no longer extends Named, so fix tests