### PR TITLE
Fix documentation task

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.kotlin-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.kotlin-module.gradle
@@ -2,3 +2,7 @@ plugins {
     id "io.micronaut.build.internal.kotlin-base"
     id "io.micronaut.build.internal.module"
 }
+
+dokkaHtmlPartial {
+    dependsOn("kaptKotlin")
+}

--- a/kotlin-runtime/build.gradle
+++ b/kotlin-runtime/build.gradle
@@ -35,4 +35,3 @@ dependencies {
 test {
     useJUnitPlatform()
 }
-


### PR DESCRIPTION
Gradle is more keen to break when tasks are modelled ambiguously.

In this case, the dokkaHtmlPartial task is using output from kaptKotlin, but it's not declared as an input.

To fix this issue, I added a dependsOn -- I couldn't find outputs from kaptKotlin to attach

Closes #507 