### PR TITLE
dokkaHtmlMultiModule.outputDirectory should be a Directory not File

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 tasks.named("dokkaHtmlMultiModule") {
-    outputDirectory.set(rootProject.layout.buildDirectory.dir("docs/api").map(d -> d.asFile))
+    outputDirectory.set(rootProject.layout.buildDirectory.dir("docs/api"))
 }
 
 task renameDokkaRootFile(type: Copy) {


### PR DESCRIPTION
Another bite of the cherry fixing https://github.com/micronaut-projects/micronaut-kotlin/issues/507

This seems to be a breaking change in dokka.  It used to accept a file provider, but now requires a directory provider.  The fix here is to stop mapping the directory to a file and just use the directory.