### PR TITLE
Add http client and message extensions and update Docs

### DIFF
--- a/kotlin-extension-functions/build.gradle
+++ b/kotlin-extension-functions/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     }
     implementation(mn.micronaut.jackson.databind)
 
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation(mn.micronaut.http.server)
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.http.server.netty)

--- a/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/http/HttpClientExtensions.kt
+++ b/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/http/HttpClientExtensions.kt
@@ -17,6 +17,7 @@ package io.micronaut.kotlin.http
 
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.client.BlockingHttpClient
 
 /**
@@ -27,7 +28,7 @@ import io.micronaut.http.client.BlockingHttpClient
  * @author Will Buck
  * @since 1.0.0
  */
-inline fun <reified T: Any> argumentOf(): Argument<T> = Argument.of(T::class.java)
+inline fun <reified T : Any> argumentOf(): Argument<T> = Argument.of(T::class.java)
 
 /**
  * Shortcut to create an argument of a list the given type
@@ -37,11 +38,26 @@ inline fun <reified T: Any> argumentOf(): Argument<T> = Argument.of(T::class.jav
  * @author Will Buck
  * @since 1.0.0
  */
-inline fun <reified T: Any> argumentOfList(): Argument<List<T>> = Argument.listOf(T::class.java)
+inline fun <reified T : Any> argumentOfList(): Argument<List<T>> = Argument.listOf(T::class.java)
 
 /**
  * Perform an HTTP request for the given request object emitting the full HTTP response from returned
- * Publisher and converting the response body to the specified type.
+ * [org.reactivestreams.Publisher] and converting the response body to the specified type. Allowing for
+ * `client.exchangeObject<Hero>(HttpRequest.GET("/heroes/any"))` instead of
+ * `client.exchange(HttpRequest.GET<Any>("/heroes/any"), Argument.of(Hero::class.java))`.
+ *
+ * @param T The response body type
+ * @param request The [HttpRequest] you want to perform
+ * @return The full [HttpResponse] with response body as an instance of [T]
+ */
+inline fun <reified T : Any> BlockingHttpClient.exchangeObject(request: HttpRequest<Any>): HttpResponse<T> =
+    exchange(request, argumentOf<T>())
+
+/**
+ * Perform an HTTP request for the given request object emitting the full HTTP response from returned
+ * Publisher and converting the response body to the specified type. Allows for
+ * `client.retrieveObject<Hero>(HttpRequest.GET("/heroes/any"))` instead of
+ * `client.retrieve(HttpRequest.GET<Any>("/heroes/any"), Argument.of(Hero::class.java))`.
  *
  * @param T The argument type
  * @param request The [HttpRequest] you want to perform
@@ -49,14 +65,27 @@ inline fun <reified T: Any> argumentOfList(): Argument<List<T>> = Argument.listO
  * @author Will Buck
  * @since 1.0.0
  */
-// tag::clientFunctionSingle[]
-inline fun <reified T: Any> BlockingHttpClient.retrieveObject(request: HttpRequest<Any>): T =
-        retrieve(request, argumentOf<T>())
-// end::clientFunctionSingle[]
+inline fun <reified T : Any> BlockingHttpClient.retrieveObject(request: HttpRequest<Any>): T =
+    retrieve(request, argumentOf<T>())
 
 /**
  * Perform an HTTP request for the given request object emitting the full HTTP response from returned
- * Publisher and converting the response body to a list of the specified type.
+ * [org.reactivestreams.Publisher] and converting the response body to a list of the specified type. Allowing for
+ * `client.exchangeList<Hero>(HttpRequest.GET("/heroes/any"))` instead of
+ * `client.exchange(HttpRequest.GET<Any>("/heroes/any"), Argument.listOf(Hero::class.java))`.
+ *
+ * @param T The response body type
+ * @param request The [HttpRequest] you want to perform
+ * @return The full [HttpResponse] with response body as an instance of [List<T>]
+ */
+inline fun <reified T : Any> BlockingHttpClient.exchangeList(request: HttpRequest<Any>): HttpResponse<List<T>> =
+    exchange(request, argumentOfList<T>())
+
+/**
+ * Perform an HTTP request for the given request object emitting the full HTTP response from returned
+ * Publisher and converting the response body to a list of the specified type. Allows for
+ * `client.retrieveList<Hero>(HttpRequest.GET("/heroes/any"))` instead of
+ * `client.retrieve(HttpRequest.GET<Any>("/heroes/any"), Argument.listOf(Hero::class.java))`.
  *
  * @param T The argument type
  * @param request The [HttpRequest] you want to perform
@@ -64,7 +93,5 @@ inline fun <reified T: Any> BlockingHttpClient.retrieveObject(request: HttpReque
  * @author Will Buck
  * @since 1.0.0
  */
-// tag::clientFunctionList[]
-inline fun <reified T: Any> BlockingHttpClient.retrieveList(request: HttpRequest<Any>): List<T> =
-        retrieve(request, argumentOfList<T>())
-// end::clientFunctionList[]
+inline fun <reified T : Any> BlockingHttpClient.retrieveList(request: HttpRequest<Any>): List<T> =
+    retrieve(request, argumentOfList<T>())

--- a/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/http/HttpMessageExtensions.kt
+++ b/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/http/HttpMessageExtensions.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.http
+
+import io.micronaut.http.HttpMessage
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Extension property to retrieve the body of the [HttpMessage] as a nullable object instead of an `Optional`.
+ * Allowing to write `message.bodyOrNull` instead of `message.body.getOrNull()`.
+ *
+ * @param B The type of the body
+ * @return The body of the message as a nullable object, or null if the body is not present
+ */
+val <B : Any> HttpMessage<B>.bodyOrNull: B?
+    get() = this.body.getOrNull()
+
+
+/**
+ * Retrieve the body of the message as an object of the given type. Allowing to write `message.getBodyObject<Foo>()`
+ * instead of `message.getBody(Argument.of(Foo::class.java)).getOrNull()` or `message.getBody(Foo::class.java)).getOrNull()`.
+ *
+ * @param T The type of the object
+ */
+inline fun <reified T : Any> HttpMessage<*>.getBodyObject(): T? = this.getBody(argumentOf<T>()).getOrNull()
+

--- a/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/runtime/MicronautExtensions.kt
+++ b/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/runtime/MicronautExtensions.kt
@@ -29,14 +29,12 @@ import io.micronaut.runtime.Micronaut
  * @author Will Buck
  * @since 2.3.1
  */
-// tag:startApplication
 inline fun <reified T : Any> startApplication(vararg args: String, initializer: Micronaut.() -> Unit = {}): ApplicationContext {
     return Micronaut.build(*args)
             .mainClass(T::class.java)
             .apply(initializer)
             .start()
 }
-// end:startApplication
 
 /**
  *  Top level function acting as a Kotlin shortcut allowing to write `mnRun<Foo>(args)`

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HeroController.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HeroController.kt
@@ -15,14 +15,26 @@
  */
 package io.micronaut.kotlin.http
 
-import io.micronaut.kotlin.http.Hero
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
 import io.micronaut.http.annotation.Get
+import java.time.Instant
 import java.time.LocalDateTime
+
+data class HeroJsonError(val testJsonErrorMessage: String, val testJsonErrorTimestamp: Instant = Instant.parse("2025-01-01T00:00:00Z"))
+class HeroException(message: String): RuntimeException(message)
 
 @Controller("/heroes")
 class HeroController {
+
+    @Error
+    fun handleException(request: HttpRequest<*>, exception: HeroException): HttpResponse<HeroJsonError> {
+        val error = HeroJsonError(testJsonErrorMessage = exception.message ?: "Unknown error")
+        return HttpResponse.serverError(error).status(HttpStatus.CONFLICT)
+    }
 
     @Get("/any")
     fun getOne(): HttpResponse<Hero> {
@@ -34,6 +46,11 @@ class HeroController {
                         LocalDateTime.of(1966, 7, 1, 0, 0)
                 )
         )
+    }
+
+    @Get("/conflict")
+    fun getMissingField(): HttpResponse<Hero> {
+        throw HeroException("conflict found is missing")
     }
 
     @Get("/list")

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt
@@ -15,51 +15,133 @@
  */
 package io.micronaut.kotlin.http
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
-import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
-import io.micronaut.kotlin.http.retrieveList
-import io.micronaut.kotlin.http.retrieveObject
-import io.micronaut.kotlin.runtime.startApplication
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.hateoas.JsonError
+import io.micronaut.runtime.server.EmbeddedServer
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.jvm.optionals.getOrNull
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class HttpClientExtensionsTest {
 
-    @Test
-    fun testBlockingHttpClientExtensions() {
-        // tag::usingClientFunctions[]
-        val embeddedServer = ApplicationContext.run(EmbeddedServer::class.java)
-        val client = embeddedServer.applicationContext.createBean(HttpClient::class.java, embeddedServer.url).toBlocking()
+    private lateinit var embeddedServer: EmbeddedServer
+    private lateinit var client: BlockingHttpClient
 
-        // Test single object retrieve extension
-        val getOneConventional = client.retrieve(HttpRequest.GET<Any>("/heroes/any"), Argument.of(Hero::class.java))
-        val getOneReified = client.retrieveObject<Hero>(HttpRequest.GET<Any>("/heroes/any"))
-        assertEquals(getOneConventional, getOneReified)
-
-        // Test list retrieve extension
-        val heroListConventional = client.retrieve(HttpRequest.GET<Any>("/heroes/list"), Argument.listOf(Hero::class.java))
-        assertEquals(heroListConventional.size, 3)
-        assertTrue(heroListConventional.find { it.alterEgo == "Diana Prince" } != null) // Let's make sure Wonder Woman is there!
-        val heroListReified = client.retrieveList<Hero>(HttpRequest.GET<Any>("/heroes/list"))
-        assertEquals(heroListConventional, heroListReified)
-        val heroListByType : List<Hero> = client.retrieveList(HttpRequest.GET<Any>("/heroes/list"))
-        assertEquals(heroListByType, heroListReified)
-        // end::usingClientFunctions[]
-        client.close()
-        embeddedServer.close()
+    @BeforeEach
+    fun setup() {
+        embeddedServer = ApplicationContext.run(EmbeddedServer::class.java)
+        client = embeddedServer.applicationContext.createBean(HttpClient::class.java, embeddedServer.url).toBlocking()
     }
 
-    object Application
+    @Test
+    fun testBlockingHttpClientExchangeSingleExtensions() {
+        // tag::usingExchangeSingleResponseFunctions[]
+        val exchangeOneConventional: HttpResponse<Hero> = client.exchange(HttpRequest.GET<Any>("/heroes/any"), Argument.of(Hero::class.java))
+        val exchangeOneReified: HttpResponse<Hero> = client.exchangeObject<Hero>(HttpRequest.GET("/heroes/any"))
+        // end::usingExchangeSingleResponseFunctions[]
+        // tag::usingHttpMessageBodyOrNull[]
+        val exchangeOneConventionalBody: Hero? = exchangeOneConventional.body.getOrNull()
+        val exchangeOneReifiedBody: Hero? = exchangeOneReified.bodyOrNull
+        // end::usingHttpMessageBodyOrNull[]
+        assertNotNull(exchangeOneConventionalBody)
+        assertNotNull(exchangeOneReifiedBody)
+        assertEquals(exchangeOneConventionalBody, exchangeOneReifiedBody)
+        assertEquals(exchangeOneConventional.status, exchangeOneReified.status)
+    }
+
 
     @Test
-    fun testStartApplication() {
-        startApplication<Application>().use {
-            assertTrue(it.containsBean(ObjectMapper::class.java))
+    fun testBlockingHttpClientRetrieveSingleExtensions() {
+        // tag::usingRetrieveSingleResponseFunctions[]
+        val retrieveOneConventional: Hero = client.retrieve(HttpRequest.GET<Any>("/heroes/any"), Argument.of(Hero::class.java))
+        val retrieveOneReified: Hero = client.retrieveObject<Hero>(HttpRequest.GET("/heroes/any"))
+        // end::usingRetrieveSingleResponseFunctions[]
+        assertEquals(retrieveOneConventional, retrieveOneReified)
+    }
+
+    @Test
+    fun testBlockingHttpClientExchangeListExtensions() {
+        // tag::usingExchangeListResponseFunctions[]
+        val exchangeListConventional: HttpResponse<MutableList<Hero>> = client.exchange(HttpRequest.GET<Any>("/heroes/list"), Argument.listOf(Hero::class.java))
+        val exchangeListReified: HttpResponse<List<Hero>> = client.exchangeList<Hero>(HttpRequest.GET("/heroes/list"))
+        // end::usingExchangeListResponseFunctions[]
+        val exchangeListConventionalBody = exchangeListConventional.body.getOrNull()
+        val exchangeListReifiedBody = exchangeListConventional.bodyOrNull
+        assertNotNull(exchangeListConventionalBody)
+        assertEquals(exchangeListConventionalBody.size, 3)
+        assertTrue(exchangeListConventionalBody.find { it.alterEgo == "Diana Prince" } != null) // Let's make sure Wonder Woman is there!
+        assertNotNull(exchangeListReifiedBody)
+        assertEquals(exchangeListConventionalBody, exchangeListReifiedBody)
+        assertEquals(exchangeListConventional.status, exchangeListReified.status)
+    }
+
+    @Test
+    fun testBlockingHttpClientRetrieveListExtensions() {
+        // tag::usingRetrieveListResponseFunctions[]
+        val retrieveListConventional: MutableList<Hero> = client.retrieve(HttpRequest.GET<Any>("/heroes/list"), Argument.listOf(Hero::class.java))
+        val retrieveListReified: List<Hero> = client.retrieveList<Hero>(HttpRequest.GET("/heroes/list"))
+        // end::usingRetrieveListResponseFunctions[]
+        assertEquals(retrieveListConventional.size, 3)
+        assertTrue(retrieveListConventional.find { it.alterEgo == "Diana Prince" } != null) // Let's make sure Wonder Woman is there!
+        assertEquals(retrieveListConventional, retrieveListReified)
+        val heroListByType: List<Hero> = client.retrieveList(HttpRequest.GET("/heroes/list"))
+        assertEquals(heroListByType, retrieveListReified)
+    }
+
+    @Test
+    fun testBlockingHttpClientExtensionsDefaultExceptionBody() {
+        val exchangeOneConventionalException = assertThrows<HttpClientResponseException> {
+            client.exchange(HttpRequest.GET<Any>("/heroes/missing-route"), Argument.of(Hero::class.java))
         }
+        val exchangeOneReifiedException = assertThrows<HttpClientResponseException> {
+            client.exchangeObject<Hero>(HttpRequest.GET("/heroes/missing-route"))
+        }
+        val exchangeOneConventionalExceptionBody = exchangeOneConventionalException.response.getBody(JsonError::class.java).getOrNull()
+        val exchangeOneReifiedExceptionBody = exchangeOneReifiedException.response.getBodyObject<JsonError>()
+        assertNotNull(exchangeOneConventionalExceptionBody)
+        assertNotNull(exchangeOneReifiedExceptionBody)
+        assertNull(exchangeOneConventionalException.response.body.getOrNull())
+        assertNull(exchangeOneReifiedException.response.bodyOrNull)
+        assertEquals(exchangeOneConventionalExceptionBody.message, exchangeOneReifiedExceptionBody.message)
+        assertEquals(exchangeOneConventionalExceptionBody.message, exchangeOneReifiedExceptionBody.message)
+        assertEquals(HttpStatus.NOT_FOUND, exchangeOneConventionalException.response.status)
+        assertEquals(exchangeOneConventionalException.response.status, exchangeOneReifiedException.response.status)
+    }
+
+    @Test
+    fun testBlockingHttpClientExtensionsCustomExceptionBody() {
+        // tag::usingHttpMessageGetBodyFunctions[]
+        val exchangeOneConventionalCustomException: HttpClientResponseException = assertThrows<HttpClientResponseException> {
+            client.exchange(HttpRequest.GET<Any>("/heroes/conflict"), Argument.of(Hero::class.java))
+        }
+        val exchangeOneReifiedCustomException: HttpClientResponseException = assertThrows<HttpClientResponseException> {
+            client.exchangeObject<Hero>(HttpRequest.GET("/heroes/conflict"))
+        }
+        val exchangeOneConventionalCustomExceptionBody: HeroJsonError? = exchangeOneConventionalCustomException.response.getBody(HeroJsonError::class.java).getOrNull()
+        val exchangeOneReifiedCustomExceptionBody: HeroJsonError? = exchangeOneReifiedCustomException.response.getBodyObject<HeroJsonError>()
+        // end::usingHttpMessageGetBodyFunctions[]
+        assertNotNull(exchangeOneConventionalCustomExceptionBody)
+        assertNotNull(exchangeOneReifiedCustomExceptionBody)
+        assertNull(exchangeOneConventionalCustomException.response.body.getOrNull())
+        assertNull(exchangeOneReifiedCustomException.response.bodyOrNull)
+        assertEquals("conflict found is missing", exchangeOneConventionalCustomExceptionBody.testJsonErrorMessage)
+        assertEquals(exchangeOneConventionalCustomExceptionBody, exchangeOneReifiedCustomExceptionBody)
+        assertEquals(HttpStatus.CONFLICT, exchangeOneConventionalCustomException.response.status)
+        assertEquals(
+            exchangeOneConventionalCustomException.response.status,
+            exchangeOneReifiedCustomException.response.status
+        )
     }
 }

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/runtime/MicronautExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/runtime/MicronautExtensionsTest.kt
@@ -16,20 +16,33 @@
 package io.micronaut.kotlin.runtime
 
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Prototype
 import io.micronaut.kotlin.context.getBean
 import io.micronaut.runtime.Micronaut
 import jakarta.inject.Singleton
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 /**
  * @author Alejandro Gomez
  */
 class MicronautExtensionsTest {
+
+    object Application
+
+    @Test
+    fun startApplication() {
+
+        val context = startApplication<Application>("test") {
+            packages("org.example.app")
+            mapError<RuntimeException> { 500 }
+        }
+        assertNotNull(context)
+        assertTrue(context.containsBean(ObjectMapper::class.java))
+    }
 
     @Test
     fun mnRun() {

--- a/kotlin-extension-functions/src/test/resources/logback.xml
+++ b/kotlin-extension-functions/src/test/resources/logback.xml
@@ -11,4 +11,6 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
+
+    <logger name="io.micronaut.http.client" level="TRACE" />
 </configuration>

--- a/src/main/docs/guide/extensionFunctions.adoc
+++ b/src/main/docs/guide/extensionFunctions.adoc
@@ -1,49 +1,15 @@
 The `micronaut-kotlin-extension-functions` dependency adds a variety of convenience functions to make using
-micronaut with kotlin more user-friendly.
+micronaut with kotlin more user-friendly. For example, https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[reified type parameters]
+help alleviate the need for using `::class.java` in many places where it would otherwise be required.
 
 dependency:io.micronaut.kotlin:micronaut-kotlin-extension-functions[]
 
-For example, https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[reified type parameters]
-help alleviate the need for using `::class.java` in many places where it would otherwise be required.
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/index.html[Micronaut Kotlin Extension Functions API Documentation]
 
-Thus, through defining a reified extension function to something like `BlockingHttpClient` like so:
-
-.Example HttpClient Extensions
-[source,kotlin]
-----
-include::kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/http/HttpClientExtensions.kt[tags=clientFunctionSingle]
-
-include::kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/http/HttpClientExtensions.kt[tags=clientFunctionList]
-----
-
-We are able to use the client a little more succinctly, as shown in this test:
-
-.Test Demonstrating Client Extension usage
-[source,kotlin]
-----
-include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingClientFunctions, indent="0"]
-----
-
-As another example, you can use a generic `startApplication<AppClass>` with a configuration lambda and generic `mapError<ExceptionClass>`, as you would might use `Micronaut.build().mainClass(App::class.java).start()`.
-
-.An Example `src/main/kotlin/SimpleApplication.kt` using the extension function.
-[source,kotlin]
-----
-object Application
-
-fun main(args: Array<String>) {
-    startApplication<Application>(*args) {
-        packages("org.example.app")
-        mapError<RuntimeException> { 500 }
-    }
-}
-----
+TIP: See the guide for https://guides.micronaut.io/latest/micronaut-kotlin-extension-fns.html[Using Kotlin Extension Functions in the Micronaut Framework] to learn more.
 
 NOTE: You will need to import the functions like this: `import io.micronaut.kotlin.FUNCTION_NAME`
-
-Full documentation of the provided extension functions can be found via https://micronaut-projects.github.io/micronaut-kotlin/latest/api/index.html[the dokka docs for this project].
 
 WARNING: Do be aware when defining extension functions in this project or your own, an extension that shadows a member function may have unexpected behavior, and does not throw a compiler error but rather warns.
 See https://discuss.kotlinlang.org/t/why-is-shadowed-extension-not-an-error/7209/11[this Kotlin discussion topic] for the latest information.
 
-TIP: See the guide for https://guides.micronaut.io/latest/micronaut-kotlin-extension-fns.html[Using Kotlin Extension Functions in the Micronaut Framework] to learn more.

--- a/src/main/docs/guide/extensionFunctions/contextExtensions.adoc
+++ b/src/main/docs/guide/extensionFunctions/contextExtensions.adoc
@@ -1,0 +1,1 @@
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/io.micronaut.kotlin.context/index.html[Context Extensions API Documentation]

--- a/src/main/docs/guide/extensionFunctions/httpExtensions.adoc
+++ b/src/main/docs/guide/extensionFunctions/httpExtensions.adoc
@@ -1,0 +1,39 @@
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/io.micronaut.kotlin.http/index.html[Http Extensions API Documentation]
+
+=== BlockingHttpClient Extensions
+
+==== Single Response Extensions
+
+.Test Demonstrating Single Response Client Extension usage
+[source,kotlin]
+----
+// Compare exchange usage
+include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingExchangeSingleResponseFunctions, indent="0"]
+
+// Compare retrieve usage
+include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingRetrieveSingleResponseFunctions, indent="0"]
+----
+
+==== List Response Extensions
+
+.Test Demonstrating List Response Client Extension usage
+[source,kotlin]
+----
+// Compare exchange usage
+include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingExchangeListResponseFunctions, indent="0"]
+
+// Compare retrieve usage
+include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingRetrieveListResponseFunctions, indent="0"]
+----
+
+=== HttpMessage Extensions
+
+.Test Demonstrating HttpMessage Extension usage
+[source,kotlin]
+----
+// Compare body member usage (Not exceptional path)
+include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingHttpMessageBodyOrNull, indent="0"]
+
+// Compare getBody() usage (Exceptional path)
+include::kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/http/HttpClientExtensionsTest.kt[tags=usingHttpMessageGetBodyFunctions, indent="0"]
+----

--- a/src/main/docs/guide/extensionFunctions/injectExtensions.adoc
+++ b/src/main/docs/guide/extensionFunctions/injectExtensions.adoc
@@ -1,0 +1,1 @@
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/io.micronaut.kotlin.inject/index.html[Inject Extensions API Documentation]

--- a/src/main/docs/guide/extensionFunctions/runtimeExtensions.adoc
+++ b/src/main/docs/guide/extensionFunctions/runtimeExtensions.adoc
@@ -1,0 +1,14 @@
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/io.micronaut.kotlin.runtime/index.html[Runtime Extensions API Documentation]
+
+.An Example Application using the extension function.
+[source,kotlin]
+----
+object Application
+
+fun main(args: Array<String>) {
+    startApplication<Application>(*args) {
+        packages("org.example.app")
+        mapError<RuntimeException> { 500 }
+    }
+}
+----

--- a/src/main/docs/guide/extensionFunctions/schedulingExtensions.adoc
+++ b/src/main/docs/guide/extensionFunctions/schedulingExtensions.adoc
@@ -1,0 +1,1 @@
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/io.micronaut.kotlin.scheduling/index.html[Scheduling Extensions API Documentation]

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,1 +1,3 @@
 This project provides various extensions and improvements to the Micronaut and Kotlin experience.
+
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/index.html[For more detailed information, see the dokka docs for the Micronaut Kotlin Modules].

--- a/src/main/docs/guide/ktor.adoc
+++ b/src/main/docs/guide/ktor.adoc
@@ -2,4 +2,8 @@ https://ktor.io/[Ktor] is a Kotlin framework for building connected applications
 
 This allows users familiar with Ktor to use Micronaut features such as Dependency Injection, AOP, configuration management and so on.
 
+dependency:io.micronaut.kotlin:micronaut-ktor[]
+
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-ktor/index.html[Micronaut ktor API Documentation].
+
 TIP: See the https://github.com/micronaut-projects/micronaut-kotlin/tree/master/examples/greeting[Example application] which demonstrates how to setup a Micronaut Ktor application

--- a/src/main/docs/guide/runtime.adoc
+++ b/src/main/docs/guide/runtime.adoc
@@ -7,11 +7,7 @@ To enable the above features add the dependency to your build:
 
 dependency:io.micronaut.kotlin:micronaut-kotlin-runtime[]
 
-=== Config4k Support
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-runtime/index.html[Micronaut Kotlin Runtime API Documentation]
 
-https://github.com/config4k/config4k[Config4k] is a type safe configuration format for Kotlin based on https://github.com/lightbend/config/blob/master/HOCON.md[HOCON (Human-Optimized Config Object Notation)]. Configuration files are defined using the `conf` extension. The following an example configuration file:
+== Config4k Support
 
-.An Example `src/main/resources/application.conf`
-----
-include::kotlin-runtime/src/test/resources/application.conf[]
-----

--- a/src/main/docs/guide/runtime/config4k.adoc
+++ b/src/main/docs/guide/runtime/config4k.adoc
@@ -1,0 +1,6 @@
+https://github.com/config4k/config4k[Config4k] is a type safe configuration format for Kotlin based on https://github.com/lightbend/config/blob/master/HOCON.md[HOCON (Human-Optimized Config Object Notation)]. Configuration files are defined using the `conf` extension. The following an example configuration file:
+
+.An Example `src/main/resources/application.conf`
+----
+include::kotlin-runtime/src/test/resources/application.conf[]
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,11 +3,17 @@ introduction:
 releaseHistory: Release History
 runtime:
   title: Kotlin Runtime Support
+  config4k: Config4k
 ktor:
   title: Ktor Support
   ktorApplication: The KtorApplication class
   ktorModules: Defining Ktor Modules
 extensionFunctions:
   title: Kotlin Extension Functions
+  contextExtensions: Context Extensions
+  httpExtensions: HTTP Extensions
+  injectExtensions: Inject Extensions
+  runtimeExtensions: Runtime Extensions
+  schedulingExtensions: Scheduling Extensions
 breaks: Breaking Changes
 repository: Repository


### PR DESCRIPTION
- Make it more obvious what is offered by the the kotlin modules
- Link out to Dokka rather than trying to add snippets of source code. And instead, leverage snippets for test/example codes.

Also interested in if other docs should be updated to encourage Kotlin extensions. For example in
- https://docs.micronaut.io/latest/guide/index.html#bindErrors
- https://micronaut-projects.github.io/micronaut-test/latest/guide/

## Dokka Updates

### Http Functions

<img width="1649" alt="Screenshot 2025-01-02 at 2 04 54 PM" src="https://github.com/user-attachments/assets/06c55fd2-f955-4b3a-9d09-81c0af65e91b" />

### Http Properties

<img width="1636" alt="Screenshot 2025-01-02 at 2 07 08 PM" src="https://github.com/user-attachments/assets/d5856401-147e-4f40-b741-e3bd417a13ce" />



## Ascii Doc Updates

### Redone Intro

Mentions Dokka right away, as I missed this for years lol. Then each section has a link as well too

<img width="810" alt="Screenshot 2025-01-02 at 2 02 09 PM" src="https://github.com/user-attachments/assets/b69b569f-acf6-4930-80bb-023b758a5f4a" />

### Redone Extensions Intro

<img width="1638" alt="Screenshot 2025-01-02 at 1 51 23 PM" src="https://github.com/user-attachments/assets/7fa88664-fa46-4dfc-bb31-44f100d3b0af" />

> [!NOTE]
> Includes subsections for each major domain of extensions for discoverability without going to Dokka

### Http Extension Example updates

<img width="1263" alt="Screenshot 2025-01-02 at 1 51 28 PM" src="https://github.com/user-attachments/assets/b74e470b-ca2e-41f7-b4c2-afe807839a86" />

