### PR TITLE
Remove Jackson dependencies from extensions module

### DIFF
--- a/kotlin-extension-functions/build.gradle
+++ b/kotlin-extension-functions/build.gradle
@@ -17,9 +17,6 @@ dependencies {
 
     api(mn.micronaut.inject)
 
-    implementation(libs.jackson.module.kotlin)
-    implementation(mn.micronaut.jackson.databind)
-
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation(mn.micronaut.http.server)
     testImplementation(mn.micronaut.http.client)
@@ -30,6 +27,8 @@ dependencies {
     testImplementation(mnTest.mockito.junit.jupiter)
     testImplementation(libs.mockito.kotlin)
 
+    testRuntimeOnly(libs.jackson.module.kotlin)
+    testRuntimeOnly(mn.micronaut.jackson.databind)
     testRuntimeOnly(mnLogging.logback.classic)
 }
 

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/runtime/MicronautExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/runtime/MicronautExtensionsTest.kt
@@ -16,7 +16,6 @@
 package io.micronaut.kotlin.runtime
 
 
-import tools.jackson.databind.ObjectMapper
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Prototype
@@ -41,7 +40,6 @@ class MicronautExtensionsTest {
             mapError<RuntimeException> { 500 }
         }
         assertNotNull(context)
-        assertTrue(context.containsBean(ObjectMapper::class.java))
     }
 
     @Test


### PR DESCRIPTION
The documentation for the extensions module makes no explicit reference indicating that these dependencies are intentional. They are not required by this module. The Kotlin runtime module does include these, and the documentation for that module does state that including transitive dependencies is a goal of that module.