### PR TITLE
fix allOpen issue(Could not find method allOpen())

### DIFF
--- a/examples/greeting/build.gradle
+++ b/examples/greeting/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id("io.micronaut.build.internal.kotlin-example")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.plugin.allopen")
 }
 
 application {
@@ -30,7 +32,7 @@ dependencies {
 }
 
 allOpen {
-    annotation("io.micronaut.aop.Around")
+        annotation("io.micronaut.aop.Around")
 }
 
 test {

--- a/kotlin-extension-functions/build.gradle
+++ b/kotlin-extension-functions/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id("io.micronaut.build.internal.kotlin-module")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 dependencies {

--- a/kotlin-runtime/build.gradle
+++ b/kotlin-runtime/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id("io.micronaut.build.internal.kotlin-module")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 dependencies {

--- a/ktor/build.gradle
+++ b/ktor/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id("io.micronaut.build.internal.kotlin-module")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 dependencies {


### PR DESCRIPTION
project won't build due to an issue with allOpen [see](https://github.com/micronaut-projects/micronaut-kotlin/actions/runs/19825182261/job/56796628739) 
The initial error ("Could not find method allOpen() [...] on project ':examples:greeting'") stemmed from the allOpen { } DSL not being available during project configuration.
and also sub-project can't recognize kapt.