### PR TITLE
Add extension functions for JsonMapper

### DIFF
--- a/kotlin-extension-functions/build.gradle
+++ b/kotlin-extension-functions/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     compileOnly(mn.micronaut.http.server)
     compileOnly(mn.micronaut.http.client)
 
+    compileOnly(mn.micronaut.json.core)
+
     api(mn.micronaut.inject)
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
@@ -26,6 +28,7 @@ dependencies {
     testImplementation(mnTest.mockito.core)
     testImplementation(mnTest.mockito.junit.jupiter)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(mn.micronaut.jackson.databind)
 
     testRuntimeOnly(libs.jackson.module.kotlin)
     testRuntimeOnly(mn.micronaut.jackson.databind)

--- a/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/json/JsonMapperExtensions.kt
+++ b/kotlin-extension-functions/src/main/kotlin/io/micronaut/kotlin/json/JsonMapperExtensions.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.json
+
+import io.micronaut.core.annotation.Experimental
+import io.micronaut.core.io.buffer.ReadBuffer
+import io.micronaut.json.JsonMapper
+import io.micronaut.json.tree.JsonNode
+import io.micronaut.kotlin.http.argumentOf
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * Transform a [JsonNode] to a value of type [T].
+ *
+ * @param tree The input JSON data.
+ * @param T Type variable of the return type.
+ * @return The deserialized value.
+ * @throws IOException IOException
+ */
+@Experimental
+@Throws(IOException::class)
+inline fun <reified T : Any> JsonMapper.readValueFromTree(tree: JsonNode): T? =
+  readValueFromTree(tree, argumentOf<T>())
+
+/**
+ * Parse and map JSON from the given stream.
+ *
+ * @param inputStream The input stream.
+ * @param T Type variable of the return type.
+ * @return The deserialized value.
+ * @throws IOException IOException
+ */
+@Experimental
+@Throws(IOException::class)
+inline fun <reified T : Any> JsonMapper.readValue(inputStream: InputStream): T? =
+  readValue(inputStream, argumentOf<T>())
+
+/**
+ * Parse and map JSON from the given byte array.
+ *
+ * @param byteArray The input data.
+ * @param T Type variable of the return type.
+ * @return The deserialized value.
+ * @throws IOException IOException
+ */
+@Experimental
+@Throws(IOException::class)
+inline fun <reified T : Any> JsonMapper.readValue(byteArray: ByteArray): T? =
+  readValue(byteArray, argumentOf<T>())
+
+/**
+ * Parse and map JSON from the given read buffer.
+ *
+ * @param readBuffer The input data.
+ * @param T Type variable of the return type.
+ * @return The deserialized value.
+ * @throws IOException IOException
+ */
+@Experimental
+@Throws(IOException::class)
+inline fun <reified T : Any> JsonMapper.readValue(readBuffer: ReadBuffer): T? =
+  readValue(readBuffer, argumentOf<T>())
+
+/**
+ * Parse and map JSON from the given string.
+ *
+ * @param string The input data.
+ * @param T Type variable of the return type.
+ * @return The deserialized value.
+ * @throws IOException IOException
+ */
+@Experimental
+@Throws(IOException::class)
+inline fun <reified T : Any> JsonMapper.readValue(string: String): T? =
+  readValue(string, argumentOf<T>())
+

--- a/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/json/JsonMapperExtensionsTest.kt
+++ b/kotlin-extension-functions/src/test/kotlin/io/micronaut/kotlin/json/JsonMapperExtensionsTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.json
+
+import io.micronaut.core.io.buffer.ReadBufferFactory
+import io.micronaut.jackson.databind.JacksonDatabindMapper
+import io.micronaut.json.JsonMapper
+import io.micronaut.kotlin.http.argumentOf
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets.UTF_8
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class JsonMapperExtensionsTest {
+
+    private val jsonMapper: JsonMapper = JacksonDatabindMapper(ObjectMapper())
+
+    open class TestData {
+      var name: String? = null
+      var value: Int = 0
+    }
+
+    @Nested
+    inner class ReadValueFromTree {
+
+        @Test
+        fun shouldReturnDeserializedValueWhenTreeContainsValidData() {
+            val testData = TestData().apply {
+                name = "test"
+                value = 42
+            }
+            val tree = jsonMapper.writeValueToTree(testData)
+
+            val result = jsonMapper.readValueFromTree<TestData>(tree)!!
+
+            assertEquals("test", result.name)
+            assertEquals(42, result.value)
+        }
+
+        @Test
+        fun shouldReturnNullWhenTreeIsNull() {
+            val tree = jsonMapper.writeValueToTree(argumentOf<TestData>(), null)
+
+            val result = jsonMapper.readValueFromTree<TestData>(tree)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class ReadValueFromInputStream {
+
+        @Test
+        fun shouldReturnDeserializedValueWhenStreamContainsValidJson() {
+            val jsonString = """{"name":"test","value":42}"""
+            val inputStream = ByteArrayInputStream(jsonString.toByteArray())
+
+            val result = jsonMapper.readValue<TestData>(inputStream)!!
+
+            assertEquals("test", result.name)
+            assertEquals(42, result.value)
+        }
+
+        @Test
+        fun shouldReturnNullWhenStreamContainsNull() {
+            val jsonString = "null"
+            val inputStream = ByteArrayInputStream(jsonString.toByteArray())
+
+            val result = jsonMapper.readValue<TestData>(inputStream)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class ReadValueFromByteArray {
+
+        @Test
+        fun shouldReturnDeserializedValueWhenByteArrayContainsValidJson() {
+            val jsonBytes = """{"name":"test","value":42}""".toByteArray()
+
+            val result = jsonMapper.readValue<TestData>(jsonBytes)!!
+
+            assertEquals("test", result.name)
+            assertEquals(42, result.value)
+        }
+
+        @Test
+        fun shouldReturnNullWhenByteArrayContainsNull() {
+            val jsonBytes = "null".toByteArray()
+
+            val result = jsonMapper.readValue<TestData>(jsonBytes)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class ReadValueFromReadBuffer {
+
+        @Test
+        fun shouldReturnDeserializedValueWhenByteBufferContainsValidJson() {
+            val readBuffer = ReadBufferFactory.getJdkFactory()
+                .copyOf("""{"name":"test","value":42}""", UTF_8)
+
+            val result = jsonMapper.readValue<TestData>(readBuffer)!!
+
+            assertEquals("test", result.name)
+            assertEquals(42, result.value)
+        }
+
+        @Test
+        fun shouldReturnNullWhenByteBufferContainsNull() {
+            val readBuffer = ReadBufferFactory.getJdkFactory()
+                .copyOf("null", UTF_8)
+
+            val result = jsonMapper.readValue<TestData>(readBuffer)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class ReadValueFromString {
+
+        @Test
+        fun shouldReturnDeserializedValueWhenStringContainsValidJson() {
+            val jsonString = """{"name":"test","value":42}"""
+
+            val result = jsonMapper.readValue<TestData>(jsonString)!!
+
+            assertEquals("test", result.name)
+            assertEquals(42, result.value)
+        }
+
+        @Test
+        fun shouldReturnNullWhenStringContainsNull() {
+            val jsonString = "null"
+
+            val result = jsonMapper.readValue<TestData>(jsonString)
+
+            assertNull(result)
+        }
+    }
+}

--- a/src/main/docs/guide/extensionFunctions.adoc
+++ b/src/main/docs/guide/extensionFunctions.adoc
@@ -1,5 +1,5 @@
 The `micronaut-kotlin-extension-functions` dependency adds a variety of convenience functions to make using
-micronaut with kotlin more user-friendly. For example, https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[reified type parameters]
+Micronaut with Kotlin more user-friendly. For example, https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[reified type parameters]
 help alleviate the need for using `::class.java` in many places where it would otherwise be required.
 
 dependency:io.micronaut.kotlin:micronaut-kotlin-extension-functions[]

--- a/src/main/docs/guide/extensionFunctions/jsonCoreExtensions.adoc
+++ b/src/main/docs/guide/extensionFunctions/jsonCoreExtensions.adoc
@@ -1,0 +1,97 @@
+TIP: https://micronaut-projects.github.io/micronaut-kotlin/latest/api/micronaut-kotlin-extension-functions/io.micronaut.kotlin.json/index.html[Serde Extensions API Documentation]
+
+=== JsonMapper Extensions
+
+The `JsonMapper` extension functions provide convenient ways to deserialize JSON from various sources using https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters[reified type parameters], eliminating the need to explicitly pass type information.
+
+==== Deserialize from JsonNode
+
+The `readValueFromTree` extension allows you to deserialize a `JsonNode` directly to a typed value without requiring explicit type arguments:
+
+.Test Demonstrating JsonNode deserialization
+[source,kotlin]
+----
+// Instead of:
+val value: MyData = jsonMapper.readValueFromTree(node, Argument.of(MyData::class.java))
+
+// You can use:
+val value = jsonMapper.readValueFromTree<MyData>(node)
+----
+
+This is particularly useful when working with the JSON tree API for partial parsing or tree manipulation operations.
+
+==== Deserialize from InputStream
+
+The `readValue` extension for `InputStream` provides a clean way to parse JSON from a stream:
+
+.Parsing JSON from an InputStream
+[source,kotlin]
+----
+// Instead of:
+val value: MyData = jsonMapper.readValue(inputStream, Argument.of(MyData::class.java))
+
+// You can use:
+val value = jsonMapper.readValue<MyData>(inputStream)
+----
+
+==== Deserialize from ByteArray
+
+The `readValue` extension for `ByteArray` is convenient for parsing JSON from raw bytes:
+
+.Parsing JSON from a ByteArray
+[source,kotlin]
+----
+// Instead of:
+val value: MyData = jsonMapper.readValue(jsonBytes, Argument.of(MyData::class.java))
+
+// You can use:
+val value = jsonMapper.readValue<MyData>(jsonBytes)
+----
+
+==== Deserialize from ReadBuffer
+
+For Micronaut's `ReadBuffer` type, the extension provides seamless deserialization:
+
+.Parsing JSON from a ByteBuffer
+[source,kotlin]
+----
+// Instead of:
+val value: MyData = jsonMapper.readValue(buffer, Argument.of(MyData::class.java))
+
+// You can use:
+val value = jsonMapper.readValue<MyData>(buffer)
+----
+
+This is especially useful in server implementations that work directly with buffers.
+
+==== Deserialize from String
+
+The `readValue` extension for `String` is the most convenient for handling JSON text:
+
+.Parsing JSON from a String
+[source,kotlin]
+----
+// Instead of:
+val value: MyData = jsonMapper.readValue(jsonString, Argument.of(MyData::class.java))
+
+// You can use:
+val value = jsonMapper.readValue<MyData>(jsonString)
+----
+
+==== Null Handling
+
+All extension functions return a nullable type (`T?`) to properly handle cases where deserialization results in JSON `null` values.
+
+.Handling null values in deserialization
+[source,kotlin]
+----
+val possiblyNull: MyData? = jsonMapper.readValue<MyData>(jsonString)
+
+if (possiblyNull != null) {
+    // Process the deserialized value
+    println(possiblyNull.name)
+} else {
+    // Handle null case
+    println("JSON was null")
+}
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -15,5 +15,6 @@ extensionFunctions:
   injectExtensions: Inject Extensions
   runtimeExtensions: Runtime Extensions
   schedulingExtensions: Scheduling Extensions
+  jsonCoreExtensions: JSON Extensions
 breaks: Breaking Changes
 repository: Repository


### PR DESCRIPTION
These read-path functions remove the need for Kotlin callers to explicitly pass Argument information.

All are marked @Experimental as the JsonMapper API is @Experimental.